### PR TITLE
EXP34 - Introduced `hasMessage` assertion for Throwable

### DIFF
--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Throwable.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Throwable.kt
@@ -1,0 +1,12 @@
+package dev.nmarsman.expect.assertions
+
+import dev.nmarsman.expect.api.Assertion
+
+fun <T : Throwable> Assertion.Builder<T>.hasMessage(expected: String): Assertion.Builder<T> =
+    assert(description = "has message {}", expected = expected) {
+        when (it.message) {
+            expected -> pass()
+            null -> fail(actual = null)
+            else -> fail(actual = it.message)
+        }
+    }

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/ThrowableTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/ThrowableTest.kt
@@ -1,0 +1,30 @@
+package dev.nmarsman.expect.assertions
+
+import de.infix.testBalloon.framework.core.testSuite
+import dev.nmarsman.expect.api.expectThrows
+import dev.nmarsman.expect.exception.AssertionFailedException
+
+val ThrowableAssertionTest by testSuite(
+    displayName = "Throwable assertion tests",
+) {
+    testSuite(name = "`hasMessage` assertions") {
+        test(name = "Passes if the subject has the expected message") {
+            expectThrows<IllegalStateException> { error("Expected message") }
+                .hasMessage("Expected message")
+        }
+
+        test(name = "Fails if the subject does not have the expected message") {
+            expectThrows<AssertionFailedException> {
+                expectThrows<IllegalStateException> { error("Actual message") }
+                    .hasMessage("Expected message")
+            }
+        }
+
+        test(name = "Fails if the subject does have a `null` message") {
+            expectThrows<AssertionFailedException> {
+                expectThrows<IllegalStateException> { throw IllegalStateException() }
+                    .hasMessage("Expected message")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes.
Focus on intent, not implementation details.
-->

Introduced assertion to assert throwables on having a message

---

## Related issue(s)

<!--
Link the related Github issue(s).
Use full links or issue keys.
-->

- [EXP34](https://github.com/nmrsmn/kotlin-expect/issues/34)

---

## Design & conventions checklist (filled by the author)

Please confirm the following:

### General
- [x] This PR has a clear and limited scope
- [x] Code follows existing naming and structural conventions
- [x] No unrelated changes are included

### Git & workflow
- [x] Branch is up to date with `main`
- [x] Commits are rebased (no merge commits)

---

## Testing

<!--
Explain how this change is tested.
-->

- [x] Unit tests added or updated **or** manual testing performed **or** code changes aren't testable
- [x] Existing tests still pass
- [x] Changes are testable without external infrastructure

Details (optional): N/A

---

## Reviewer checklist

### Correctness & quality
- [x] The change does what it claims to do
- [x] Code is readable and maintainable
- [x] No unnecessary complexity introduced

### Architecture
- [x] Architectural boundaries are respected
- [x] No hidden architectural decisions introduced

### Risk & impact
- [x] Change is low-risk / well-isolated **or** risk is understood and acceptable

---

## Notes for reviewer

<!--
Anything the reviewer should pay special attention to?
Trade-offs, open questions, or known limitations.
-->

N/A

---

## Post-merge follow-ups (optional)

<!--
List any follow-up work that is explicitly out of scope for this PR.
Please note them down by adding checkboxes, so that follow-ups and their state can be tracked
-->

- N/A
