### PR TITLE
EXP31 - Introduce pending status as using failed as default feels "wr…

### DIFF
--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/internal/AssertionResult.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/internal/AssertionResult.kt
@@ -16,6 +16,11 @@ internal class AssertionResult<S>(
     sealed interface Status {
         val symbol: String
 
+        data object Pending : Status {
+            override val symbol: String
+                get() = "…"
+        }
+
         data class Passed(
             val description: String?,
             val actual: Any?,
@@ -34,7 +39,7 @@ internal class AssertionResult<S>(
         }
     }
 
-    var status: Status = Status.Failed(null, null, null)
+    var status: Status = Status.Pending
         private set
 
     val failed: Boolean

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/internal/AssertionResultTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/internal/AssertionResultTest.kt
@@ -7,7 +7,7 @@ import dev.nmarsman.expect.assertions.isEqualTo
 import dev.nmarsman.expect.assertions.isNull
 
 val AssertionResultTest by testSuite(
-    displayName = "AssertionResult tests",
+    displayName = "Assertion result tests",
 ) {
     val subject = testFixture {
         AssertionSubject(
@@ -61,11 +61,11 @@ val AssertionResultTest by testSuite(
     }
 
     testSuite(name = "Status") {
-        test(name = "Default status is Failed") {
+        test(name = "Default status is Pending") {
             val result = AssertionResult(parent = subject.invoke(), description = "description", expected = "expected")
 
             expectThat(subject = result.status)
-                .isA<AssertionResult.Status.Failed>()
+                .isA<AssertionResult.Status.Pending>()
         }
 
         test(name = "Status is Passed after calling pass") {


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes.
Focus on intent, not implementation details.
-->

Introduced Pending status for unchecked assertion results

---

## Related issue(s)

<!--
Link the related Github issue(s).
Use full links or issue keys.
-->

- [EXP31](https://github.com/nmrsmn/kotlin-expect/issues/31)

---

## Design & conventions checklist (filled by the author)

Please confirm the following:

### General
- [x] This PR has a clear and limited scope
- [x] Code follows existing naming and structural conventions
- [x] No unrelated changes are included

### Git & workflow
- [x] Branch is up to date with `main`
- [x] Commits are rebased (no merge commits)

---

## Testing

<!--
Explain how this change is tested.
-->

- [x] Unit tests added or updated **or** manual testing performed **or** code changes aren't testable
- [x] Existing tests still pass
- [x] Changes are testable without external infrastructure

Details (optional): N/A

---

## Reviewer checklist

### Correctness & quality
- [x] The change does what it claims to do
- [x] Code is readable and maintainable
- [x] No unnecessary complexity introduced

### Architecture
- [x] Architectural boundaries are respected
- [x] No hidden architectural decisions introduced

### Risk & impact
- [x] Change is low-risk / well-isolated **or** risk is understood and acceptable

---

## Notes for reviewer

<!--
Anything the reviewer should pay special attention to?
Trade-offs, open questions, or known limitations.
-->

N/A

---

## Post-merge follow-ups (optional)

<!--
List any follow-up work that is explicitly out of scope for this PR.
Please note them down by adding checkboxes, so that follow-ups and their state can be tracked
-->

- N/A
