### PR TITLE
EXP50 - Added `size` as a convenience (mapping) function on collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ expectThat(12)
 ```kotlin
 expectThat(Color.RED)
     .isIn(Color.RED, Color.GREEN)
+
+expectThat(Color.RED)
+    .name()
+    .isEqualTo("RED")
+
+expectThat(Color.RED)
+    .ordinal()
+    .isEqualTo(1)
 ```
 
 ### Collection assertions

--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Enum.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Enum.kt
@@ -10,3 +10,15 @@ fun <T : Enum<T>> Assertion.Builder<T>.isOneOf(vararg values: T): Assertion.Buil
             fail()
         }
     }
+
+/**
+ * Maps an assertion on an enum to an assertion on its name.
+ */
+fun <T : Enum<T>> Assertion.Builder<T>.name(): Assertion.Builder<String> =
+    get(Enum<T>::name)
+
+/**
+ * Maps an assertion on an enum to an assertion on its ordinal value.
+ */
+fun <T : Enum<T>> Assertion.Builder<T>.ordinal(): Assertion.Builder<Int> =
+    get(Enum<T>::ordinal)

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/EnumTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/EnumTest.kt
@@ -28,4 +28,20 @@ val EnumAssertionTest by testSuite(
             }
         }
     }
+
+    testSuite(name = "`name` mapper function") {
+        test(name = "Passes if the mapped (name) subject is equal to") {
+            expectThat(Direction.NORTH)
+                .name()
+                .isEqualTo("NORTH")
+        }
+    }
+
+    testSuite(name = "`ordinal` mapper function") {
+        test(name = "Passes if the mapped (ordinal) subject is equal to") {
+            expectThat(Direction.NORTH)
+                .ordinal()
+                .isEqualTo(0)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes.
Focus on intent, not implementation details.
-->

Added `size` as a convenience (mapping) function on collections

---

## Related issue(s)

<!--
Link the related Github issue(s).
Use full links or issue keys.
-->

- [EXP50](https://github.com/nmrsmn/kotlin-expect/issues/50)

---

## Design & conventions checklist (filled by the author)

Please confirm the following:

### General
- [x] This PR has a clear and limited scope
- [x] Code follows existing naming and structural conventions
- [x] No unrelated changes are included

### Git & workflow
- [x] Branch is up to date with `main`
- [x] Commits are rebased (no merge commits)

---

## Testing

<!--
Explain how this change is tested.
-->

- [x] Unit tests added or updated **or** manual testing performed **or** code changes aren't testable
- [x] Existing tests still pass
- [x] Changes are testable without external infrastructure

Details (optional): N/A

---

## Reviewer checklist

### Correctness & quality
- [x] The change does what it claims to do
- [x] Code is readable and maintainable
- [x] No unnecessary complexity introduced

### Architecture
- [x] Architectural boundaries are respected
- [x] No hidden architectural decisions introduced

### Risk & impact
- [x] Change is low-risk / well-isolated **or** risk is understood and acceptable

---

## Notes for reviewer

<!--
Anything the reviewer should pay special attention to?
Trade-offs, open questions, or known limitations.
-->

N/A

---

## Post-merge follow-ups (optional)

<!--
List any follow-up work that is explicitly out of scope for this PR.
Please note them down by adding checkboxes, so that follow-ups and their state can be tracked
-->

- N/A
