### PR TITLE
EXP51 - Add convenience mapping functions for iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,18 @@ expectThat(listOf(1, 2, 3))
     .hasSize(3)
     .size()
     .isGreaterThan(2)
+
+expectThat(listOf(1))
+    .single()
+    .isEqualTo(1)
+
+expectThat(listOf(1, 2, 3))
+    .first()
+    .isEqualTo(1)
+
+expectThat(listOf(1, 2, 3))
+    .last()
+    .isEqualTo(3)
 ```
 
 ### Map assertions

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ expectThat(listOf(1, 2, 3))
 expectThat(listOf(1, 2, 3))
     .last()
     .isEqualTo(3)
+
+expectThat(listOf(1, 2, 3))
+    .filter { it > 1 }
+    .hasSize(2)
+
+expectThat(listOf("item1", "item2", "item3"))
+    .flatMap { it.toCharArray().toList() }
+    .filter { it.isDigit() }
+    .containsExactly('1', '2', '3')
+
+expectThat(listOf(1, 2, 3))
+    .map { it * 2 }
+    .containsExactly(2, 4, 6)
 ```
 
 ### Map assertions

--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Iterable.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Iterable.kt
@@ -284,3 +284,48 @@ fun <T : Iterable<E>, E> Assertion.Builder<T>.isSorted(comparator: Comparator<E>
  */
 fun <T : Iterable<E>, E : Comparable<E>> Assertion.Builder<T>.isSorted(): Assertion.Builder<T> =
     isSorted(comparator = naturalOrder())
+
+/**
+ * Maps an assertion on an iterable to an assertion on the first element of the subject iterable.
+ */
+fun <T : Iterable<E>, E> Assertion.Builder<T>.first(): Assertion.Builder<E> =
+    get(
+        description = "first element",
+    ) {
+        first()
+    }
+
+/**
+ * Maps an assertion on an iterable to an assertion on the last element of the subject iterable.
+ */
+fun <T : Iterable<E>, E> Assertion.Builder<T>.last(): Assertion.Builder<E> =
+    get(
+        description = "last element",
+    ) {
+        last()
+    }
+
+/**
+ * Maps an assertion on an iterable to an assertion on the number of elements in the subject iterable.
+ */
+fun <T : Iterable<*>> Assertion.Builder<T>.count(): Assertion.Builder<Int> =
+    get(Iterable<*>::count)
+
+/**
+ * Maps an assertion on a collection to an assertion on the single element of the subject collection.
+ * Whenever the subject collection does not contain exactly one element this assertion fails.
+ */
+fun <T : Collection<E>, E> Assertion.Builder<T>.single(): Assertion.Builder<E> =
+    assert(
+        description = "has only one element",
+    ) {
+        if (it.size == 1) {
+            pass()
+        } else {
+            fail()
+        }
+    }
+        .get(
+            description = "single element {}",
+            function = { single() },
+        )

--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Iterable.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/assertions/Iterable.kt
@@ -329,3 +329,29 @@ fun <T : Collection<E>, E> Assertion.Builder<T>.single(): Assertion.Builder<E> =
             description = "single element {}",
             function = { single() },
         )
+
+/**
+ * Maps an assertion on an iterable to an assertion on a list of all elements of the subject that match `predicate`.
+ */
+fun <T : Iterable<E>, E> Assertion.Builder<T>.filter(predicate: (E) -> Boolean): Assertion.Builder<Collection<E>> =
+    get {
+        filter(predicate)
+    }
+
+/**
+ * Maps an assertion on an iterable to an assertion over a flattened list of the results of
+ * [transform] for each element in the subject iterable.
+ */
+fun <T : Iterable<E>, E, R> Assertion.Builder<T>.flatMap(transform: (E) -> Iterable<R>): Assertion.Builder<List<R>> =
+    get {
+        flatMap(transform)
+    }
+
+/**
+ * Maps an assertion on an iterable to an assertion on a list of the results of
+ * [function] for each element in the subject iterable.
+ */
+fun <T : Iterable<E>, E, R> Assertion.Builder<T>.map(function: (E) -> R): Assertion.Builder<Collection<R>> =
+    get {
+        map(function)
+    }

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/IterableTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/IterableTest.kt
@@ -300,4 +300,66 @@ val IterableAssertionTest by testSuite(
             }
         }
     }
+
+    testSuite(name = "`first` mapper function") {
+        test(name = "Passes if the mapped (first) subject is equal to") {
+            expectThat(listOf("item1", "item2", "item3"))
+                .first()
+                .isEqualTo("item1")
+        }
+
+        test(name = "Fails if the subject is empty") {
+            expectThrows<NoSuchElementException> {
+                expectThat(emptyList<Int>())
+                    .first()
+            }
+        }
+    }
+
+    testSuite(name = "`last` mapper function") {
+        test(name = "Passes if the mapped (last) subject is equal to") {
+            expectThat(listOf("item1", "item2", "item3"))
+                .last()
+                .isEqualTo("item3")
+        }
+
+        test(name = "Fails if the subject is empty") {
+            expectThrows<NoSuchElementException> {
+                expectThat(emptyList<Int>())
+                    .last()
+            }
+        }
+    }
+
+    testSuite(name = "`single` mapper function") {
+        test(name = "Passes if the mapped (single) subject is equal to") {
+            expectThat(listOf("item1"))
+                .single()
+                .isEqualTo("item1")
+        }
+
+        test(name = "Fails if the subject is empty") {
+            expectThrows<AssertionFailedException> {
+                expectThat(emptyList<Int>())
+                    .single()
+            }.hasMessage(
+                """
+                    |▼ Expect that []:
+                    |   ✗ has only one element
+                """.trimMargin(),
+            )
+        }
+
+        test(name = "Fails if the subject has multiple elements") {
+            expectThrows<AssertionFailedException> {
+                expectThat(listOf("item1", "item2", "item3"))
+                    .single()
+            }.hasMessage(
+                """
+                    |▼ Expect that ["item1", "item2", "item3"]:
+                    |   ✗ has only one element
+                """.trimMargin(),
+            )
+        }
+    }
 }

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/IterableTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/assertions/IterableTest.kt
@@ -362,4 +362,28 @@ val IterableAssertionTest by testSuite(
             )
         }
     }
+
+    testSuite(name = "`filter` mapper function") {
+        test(name = "Passes if the mapped (filter) subject is equal to") {
+            expectThat(listOf("item1", "item2", "item3"))
+                .filter { it == "item1" }
+                .hasSize(1)
+        }
+    }
+
+    testSuite(name = "`flatMap` mapper function") {
+        test(name = "Passes if the mapped (flatMap) subject is equal to") {
+            expectThat(listOf("item1", "item2", "item3"))
+                .flatMap { it.toCharArray().toList() }
+                .contains('1', '2', '3')
+        }
+    }
+
+    testSuite(name = "`map` mapper function") {
+        test(name = "Passes if the mapped (map) subject is equal to") {
+            expectThat(listOf("item1", "item3", "item2"))
+                .map { it.last() }
+                .containsExactlyInAnyOrder('1', '2', '3')
+        }
+    }
 }


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes.
Focus on intent, not implementation details.
-->

Added convenience mapping functions for iterable

---

## Related issue(s)

<!--
Link the related Github issue(s).
Use full links or issue keys.
-->

- [EXP51](https://github.com/nmrsmn/kotlin-expect/issues/51)

---

## Design & conventions checklist (filled by the author)

Please confirm the following:

### General
- [x] This PR has a clear and limited scope
- [x] Code follows existing naming and structural conventions
- [x] No unrelated changes are included

### Git & workflow
- [x] Branch is up to date with `main`
- [x] Commits are rebased (no merge commits)

---

## Testing

<!--
Explain how this change is tested.
-->

- [x] Unit tests added or updated **or** manual testing performed **or** code changes aren't testable
- [x] Existing tests still pass
- [x] Changes are testable without external infrastructure

Details (optional): N/A

---

## Reviewer checklist

### Correctness & quality
- [x] The change does what it claims to do
- [x] Code is readable and maintainable
- [x] No unnecessary complexity introduced

### Architecture
- [x] Architectural boundaries are respected
- [x] No hidden architectural decisions introduced

### Risk & impact
- [x] Change is low-risk / well-isolated **or** risk is understood and acceptable

---

## Notes for reviewer

<!--
Anything the reviewer should pay special attention to?
Trade-offs, open questions, or known limitations.
-->

N/A

---

## Post-merge follow-ups (optional)

<!--
List any follow-up work that is explicitly out of scope for this PR.
Please note them down by adding checkboxes, so that follow-ups and their state can be tracked
-->

- N/A
