### PR TITLE
EXP-86 - Added support for suspending blocks when using expect throws

### DIFF
--- a/core/src/commonMain/kotlin/dev/nmarsman/expect/api/Expect.kt
+++ b/core/src/commonMain/kotlin/dev/nmarsman/expect/api/Expect.kt
@@ -25,7 +25,7 @@ fun <T> expectThat(subject: T): Assertion.Builder<T> =
  * about messages, root causes, etc.
  */
 @Suppress("UNCHECKED_CAST", "TooGenericExceptionCaught")
-inline fun <reified T : Throwable> expectThrows(crossinline block: () -> Unit): Assertion.Builder<T> =
+suspend inline fun <reified T : Throwable> expectThrows(crossinline block: suspend () -> Unit): Assertion.Builder<T> =
     expectThat(
         subject = try {
             block.invoke()

--- a/core/src/commonTest/kotlin/dev/nmarsman/expect/ExpectThrowsTest.kt
+++ b/core/src/commonTest/kotlin/dev/nmarsman/expect/ExpectThrowsTest.kt
@@ -4,6 +4,10 @@ import de.infix.testBalloon.framework.core.testSuite
 import dev.nmarsman.expect.api.expectThat
 import dev.nmarsman.expect.api.expectThrows
 import dev.nmarsman.expect.assertions.isEqualTo
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
 
 val ExpectThrowsTest by testSuite {
     test(name = "Should pass when expected exception is thrown") {
@@ -49,4 +53,14 @@ val ExpectThrowsTest by testSuite {
                 )
         }
     }
+
+    test(name = "Should allow suspending function to be used as method") {
+        expectThrows<TimeoutCancellationException> {
+            test()
+        }
+    }
+}
+
+suspend fun test() = withTimeout(1.seconds) {
+    delay(2.seconds)
 }


### PR DESCRIPTION
## Summary

<!--
Briefly describe what this PR changes.
Focus on intent, not implementation details.
-->

Added support for suspending blocks when using expect throws

---

## Related issue(s)

<!--
Link the related Github issue(s).
Use full links or issue keys.
-->

- [EXP86](https://github.com/nmrsmn/kotlin-expect/issues/86)

---

## Design & conventions checklist (filled by the author)

Please confirm the following:

### General
- [x] This PR has a clear and limited scope
- [x] Code follows existing naming and structural conventions
- [x] No unrelated changes are included

### Git & workflow
- [x] Branch is up to date with `main`
- [x] Commits are rebased (no merge commits)

---

## Testing

<!--
Explain how this change is tested.
-->

- [x] Unit tests added or updated **or** manual testing performed **or** code changes aren't testable
- [x] Existing tests still pass
- [x] Changes are testable without external infrastructure

Details (optional): N/A

---

## Reviewer checklist

### Correctness & quality
- [x] The change does what it claims to do
- [x] Code is readable and maintainable
- [x] No unnecessary complexity introduced

### Architecture
- [x] Architectural boundaries are respected
- [x] No hidden architectural decisions introduced

### Risk & impact
- [x] Change is low-risk / well-isolated **or** risk is understood and acceptable

---

## Notes for reviewer

<!--
Anything the reviewer should pay special attention to?
Trade-offs, open questions, or known limitations.
-->

N/A

---

## Post-merge follow-ups (optional)

<!--
List any follow-up work that is explicitly out of scope for this PR.
Please note them down by adding checkboxes, so that follow-ups and their state can be tracked
-->

- N/A
